### PR TITLE
DELIVERY-343: Update prometheus_exporter to include status code metric

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "harperdb_prometheus_exporter",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "HarperDB Prometheus Exporter",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
I added a new response_status_code_gauge to record metrics by the numeric status code in the metric name. I also put conditions around the clustering and replication sections as it causes errors if clustering is not enabled.