### PR TITLE
Make CPU utilization a number instead of a string

### DIFF
--- a/resources.js
+++ b/resources.js
@@ -143,7 +143,7 @@ class metrics extends Resource {
     logger.debug(`CPU time: ${cpuTime} µs`);
     logger.debug(`Time elapsed: ${timeElapsed} µs`);
 
-    const cpuPercent = (cpuTime / timeElapsed).toFixed(2);
+    const cpuPercent = Math.round((cpuTime / timeElapsed) * 1e2) / 1e2;
     logger.debug(`CPU utilization: ${cpuPercent}%`);
 
     return {


### PR DESCRIPTION
Found one minor issue with the tests I added to the core metrics equivalent of this and figured it would be good to bring over here too.

`Number.toFixed()` returns a string. This `Math.round` construction accomplishes the same thing but keeps it a number.